### PR TITLE
Increase time for pre-commit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
   pre-commit:
     if: always()
     runs-on: ubuntu-latest
-    timeout-minutes: 4
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Pre-commit in CI are failing at the moment due to time constraint. The time limit has been increased to 10 minutes.