### PR TITLE
Identify recommended item in AgendaBasedSimulator.generate_response

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,10 @@ repos:
         name: docformatter
         description: "Formats docstrings to follow PEP 257."
         entry: docformatter
-        args: [--in-place --wrap-summaries 80 --wrap-descriptions 80]
+        args: 
+          - --in-place
+          - --wrap-summaries=80
+          - --wrap-descriptions=80
         language: python
         types: [python]
 -   repo: local

--- a/data/interaction_models/crs_v1.yaml
+++ b/data/interaction_models/crs_v1.yaml
@@ -4,7 +4,7 @@ description: Intent schema for CIR by Afzali, Drzewiecki, and Balog
 # Minimum intents required
 required_intents:
   INTENT_START: DISCLOSE.NON-DISCLOSE
-  INTENT_STOP: STOP
+  INTENT_STOP: COMPLETE
   INTENT_ITEM_CONSUMED: NOTE.YES
   INTENT_LIKE: NOTE.LIKE
   INTENT_DISLIKE: NOTE.DISLIKE

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,3 +9,4 @@ types-PyYAML
 types-requests
 dialoguekit==0.0.8
 confuse
+websockets<11.0

--- a/usersimcrs/items/item_collection.py
+++ b/usersimcrs/items/item_collection.py
@@ -8,6 +8,7 @@ to properties (i.e., domain slots).
 import csv
 from typing import Any, Dict, List, Set
 
+from dialoguekit.core.annotation import Annotation
 from dialoguekit.core.domain import Domain
 
 from usersimcrs.items.item import Item
@@ -122,3 +123,23 @@ class ItemCollection:
                 else:
                     values.add(value)
         return values
+
+    def get_items_by_properties(
+        self, annotations: List[Annotation]
+    ) -> List[Item]:
+        """Returns a list of items that match the given utterance annotations.
+
+        Args:
+            annotations: List of annotation.
+
+        Returns:
+            List of matching items.
+        """
+        matching_items: List[Item] = []
+        for item in self._items.values():
+            if all(
+                item.get_property(annotation.slot) == annotation.value
+                for annotation in annotations
+            ):
+                matching_items.append(item)
+        return matching_items

--- a/usersimcrs/items/item_collection.py
+++ b/usersimcrs/items/item_collection.py
@@ -136,6 +136,9 @@ class ItemCollection:
             List of matching items.
         """
         matching_items: List[Item] = []
+
+        # TODO: Refactor to use a more efficient data structure.
+        # See: https://github.com/iai-group/UserSimCRS/issues/137
         for item in self._items.values():
             if all(
                 item.get_property(annotation.slot) == annotation.value

--- a/usersimcrs/items/ratings.py
+++ b/usersimcrs/items/ratings.py
@@ -1,7 +1,7 @@
 """Represents item ratings and provides access either based on items or users.
 
-Ratings are normalized in the [-1,1] range, where -1 corresponds to
-(strong) dislike, 0 is neutral, and 1 is (strong) like.
+Ratings are normalized in the [-1,1] range, where -1 corresponds to (strong)
+dislike, 0 is neutral, and 1 is (strong) like.
 """
 
 import csv

--- a/usersimcrs/items/ratings.py
+++ b/usersimcrs/items/ratings.py
@@ -2,9 +2,6 @@
 
 Ratings are normalized in the [-1,1] range, where -1 corresponds to
 (strong) dislike, 0 is neutral, and 1 is (strong) like.
-
-TODO: Create tests for this file
-See: https://github.com/iai-group/UserSimCRS/issues/109
 """
 
 import csv

--- a/usersimcrs/run_simulation.py
+++ b/usersimcrs/run_simulation.py
@@ -327,9 +327,8 @@ def load_rasa_diet_classifier(
 
     agent_intents_str: Set[str] = set()
     for v in intent_schema["user_intents"].values():
-        intents = v.get("expected_agent_intents", [])
-        if intents:
-            agent_intents_str.update(intents)
+        if "expected_agent_intents" in v:
+            agent_intents_str.update(v["expected_agent_intents"])
     # agent_intents_str = intent_schema["agent_elicit_intents"]
     # agent_intents_str.extend(intent_schema["agent_set_retrieval"])
     agent_intents = [Intent(intent) for intent in agent_intents_str]

--- a/usersimcrs/run_simulation.py
+++ b/usersimcrs/run_simulation.py
@@ -327,8 +327,8 @@ def load_rasa_diet_classifier(
 
     agent_intents_str: Set[str] = set()
     for v in intent_schema["user_intents"].values():
-        if "expected_agent_intents" in v:
-            agent_intents_str.update(v["expected_agent_intents"])
+        intents = v.get("expected_agent_intents", []) or []
+        agent_intents_str.update(intents)
     # agent_intents_str = intent_schema["agent_elicit_intents"]
     # agent_intents_str.extend(intent_schema["agent_set_retrieval"])
     agent_intents = [Intent(intent) for intent in agent_intents_str]

--- a/usersimcrs/run_simulation.py
+++ b/usersimcrs/run_simulation.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import logging
 import os
+from typing import Set
 
 import confuse
 import requests
@@ -324,8 +325,13 @@ def load_rasa_diet_classifier(
     intent_schema_file = config["intents"].get()
     intent_schema = yaml.load(open(intent_schema_file), Loader=yaml.FullLoader)
 
-    agent_intents_str = intent_schema["agent_elicit_intents"]
-    agent_intents_str.extend(intent_schema["agent_set_retrieval"])
+    agent_intents_str: Set[str] = set()
+    for v in intent_schema["user_intents"].values():
+        intents = v.get("expected_agent_intents", [])
+        if intents:
+            agent_intents_str.update(intents)
+    # agent_intents_str = intent_schema["agent_elicit_intents"]
+    # agent_intents_str.extend(intent_schema["agent_set_retrieval"])
     agent_intents = [Intent(intent) for intent in agent_intents_str]
     intent_classifier = IntentClassifierRasa(
         agent_intents,

--- a/usersimcrs/simulator/agenda_based/agenda_based_simulator.py
+++ b/usersimcrs/simulator/agenda_based/agenda_based_simulator.py
@@ -182,6 +182,7 @@ class AgendaBasedSimulator(UserSimulator):
                 if agent_annotations
                 else []
             )
+            # The first identified item is considered the recommended item.
             item_id = possible_items[0].id if possible_items else None
             response_intent = self._generate_item_preference_response_intent(
                 item_id

--- a/usersimcrs/simulator/agenda_based/agenda_based_simulator.py
+++ b/usersimcrs/simulator/agenda_based/agenda_based_simulator.py
@@ -142,7 +142,12 @@ class AgendaBasedSimulator(UserSimulator):
             agent_intent
         ):
             # TODO: Extract the ID of the recommended item:
-            item_id = None
+            possible_items = (
+                self._item_collection.get_items_by_properties(agent_annotations)
+                if agent_annotations
+                else []
+            )
+            item_id = possible_items[0].id if possible_items else None
 
             # Determine user preference for the agent's recommendation.
             # First, check if the user has already consumed the item.

--- a/usersimcrs/simulator/agenda_based/agenda_based_simulator.py
+++ b/usersimcrs/simulator/agenda_based/agenda_based_simulator.py
@@ -183,6 +183,8 @@ class AgendaBasedSimulator(UserSimulator):
                 else []
             )
             # The first identified item is considered the recommended item.
+            # TODO: Handle multiple possible items.
+            # See: https://github.com/iai-group/UserSimCRS/issues/138
             item_id = possible_items[0].id if possible_items else None
             response_intent = self._generate_item_preference_response_intent(
                 item_id

--- a/usersimcrs/simulator/agenda_based/agenda_based_simulator.py
+++ b/usersimcrs/simulator/agenda_based/agenda_based_simulator.py
@@ -70,8 +70,7 @@ class AgendaBasedSimulator(UserSimulator):
         """
         if item_id is None:
             # The recommended item was not found in the item collection.
-            # response_intent = self._interaction_model.INTENT_DONT_KNOW  # type: ignore[attr-defined] # noqa
-            response_intent = self._interaction_model.INTENT_NEUTRAL  # type: ignore[attr-defined] # noqa
+            response_intent = self._interaction_model.INTENT_DONT_KNOW  # type: ignore[attr-defined] # noqa
         else:
             # Determine user preference for the agent's recommendation.
             # First, check if the user has already consumed the item.

--- a/usersimcrs/simulator/agenda_based/agenda_based_simulator.py
+++ b/usersimcrs/simulator/agenda_based/agenda_based_simulator.py
@@ -70,28 +70,28 @@ class AgendaBasedSimulator(UserSimulator):
         """
         if item_id is None:
             # The recommended item was not found in the item collection.
-            response_intent = self._interaction_model.INTENT_DONT_KNOW  # type: ignore[attr-defined] # noqa
+            return self._interaction_model.INTENT_DONT_KNOW  # type: ignore[attr-defined] # noqa
+
+        # Check if the user has already consumed the item.
+        if self._preference_model.is_item_consumed(item_id):
+            # Currently, the user only responds by saying that they
+            # already consumed the item. If there is a follow-up
+            # question by the agent whether they've liked it, that
+            # should end up in the other branch of the fork.
+            return self._interaction_model.INTENT_ITEM_CONSUMED  # type: ignore[attr-defined] # noqa
+
+        # Get a response based on the recommendation. Currently, the
+        # user responds immediately with a like/dislike, but it
+        # could ask questions about the item before deciding (this
+        # should be based on the agenda).
+        preference = self._preference_model.get_item_preference(item_id)
+        if preference > self._preference_model.PREFERENCE_THRESHOLD:
+            response_intent = self._interaction_model.INTENT_LIKE  # type: ignore[attr-defined] # noqa
+        elif preference < -self._preference_model.PREFERENCE_THRESHOLD:
+            response_intent = self._interaction_model.INTENT_DISLIKE  # type: ignore[attr-defined] # noqa
         else:
-            # Determine user preference for the agent's recommendation.
-            # First, check if the user has already consumed the item.
-            if self._preference_model.is_item_consumed(item_id):
-                # Currently, the user only responds by saying that they
-                # already consumed the item. If there is a follow-up
-                # question by the agent whether they've liked it, that
-                # should end up in the other branch of the fork.
-                response_intent = self._interaction_model.INTENT_ITEM_CONSUMED  # type: ignore[attr-defined] # noqa
-            else:
-                # Get a response based on the recommendation. Currently, the
-                # user responds immediately with a like/dislike, but it
-                # could ask questions about the item before deciding (this
-                # should be based on the agenda).
-                preference = self._preference_model.get_item_preference(item_id)
-                if preference > self._preference_model.PREFERENCE_THRESHOLD:
-                    response_intent = self._interaction_model.INTENT_LIKE  # type: ignore[attr-defined] # noqa
-                elif preference < -self._preference_model.PREFERENCE_THRESHOLD:
-                    response_intent = self._interaction_model.INTENT_DISLIKE  # type: ignore[attr-defined] # noqa
-                else:
-                    response_intent = self._interaction_model.INTENT_NEUTRAL  # type: ignore[attr-defined] # noqa
+            response_intent = self._interaction_model.INTENT_NEUTRAL  # type: ignore[attr-defined] # noqa
+
         return response_intent
 
     def generate_response(

--- a/usersimcrs/simulator/agenda_based/agenda_based_simulator.py
+++ b/usersimcrs/simulator/agenda_based/agenda_based_simulator.py
@@ -3,6 +3,7 @@
 from dialoguekit.core.annotated_utterance import AnnotatedUtterance
 from dialoguekit.core.annotation import Annotation
 from dialoguekit.core.domain import Domain
+from dialoguekit.core.intent import Intent
 from dialoguekit.core.utterance import Utterance
 from dialoguekit.nlg import ConditionalNLG
 from dialoguekit.nlu.nlu import NLU
@@ -57,6 +58,42 @@ class AgendaBasedSimulator(UserSimulator):
             User utterance.
         """
         return self.generate_response(agent_utterance)
+
+    def _generate_item_preference_response_intent(self, item_id: str) -> Intent:
+        """Generates response preference intent for a given item id.
+
+        Args:
+            item_id: Item id.
+
+        Returns:
+            Preference intent.
+        """
+        if item_id is None:
+            # The recommended item was not found in the item collection.
+            # response_intent = self._interaction_model.INTENT_DONT_KNOW  # type: ignore[attr-defined] # noqa
+            response_intent = self._interaction_model.INTENT_NEUTRAL  # type: ignore[attr-defined] # noqa
+        else:
+            # Determine user preference for the agent's recommendation.
+            # First, check if the user has already consumed the item.
+            if self._preference_model.is_item_consumed(item_id):
+                # Currently, the user only responds by saying that they
+                # already consumed the item. If there is a follow-up
+                # question by the agent whether they've liked it, that
+                # should end up in the other branch of the fork.
+                response_intent = self._interaction_model.INTENT_ITEM_CONSUMED  # type: ignore[attr-defined] # noqa
+            else:
+                # Get a response based on the recommendation. Currently, the
+                # user responds immediately with a like/dislike, but it
+                # could ask questions about the item before deciding (this
+                # should be based on the agenda).
+                preference = self._preference_model.get_item_preference(item_id)
+                if preference > self._preference_model.PREFERENCE_THRESHOLD:
+                    response_intent = self._interaction_model.INTENT_LIKE  # type: ignore[attr-defined] # noqa
+                elif preference < -self._preference_model.PREFERENCE_THRESHOLD:
+                    response_intent = self._interaction_model.INTENT_DISLIKE  # type: ignore[attr-defined] # noqa
+                else:
+                    response_intent = self._interaction_model.INTENT_NEUTRAL  # type: ignore[attr-defined] # noqa
+        return response_intent
 
     def generate_response(
         self, agent_utterance: Utterance
@@ -147,37 +184,9 @@ class AgendaBasedSimulator(UserSimulator):
                 else []
             )
             item_id = possible_items[0].id if possible_items else None
-
-            if item_id is None:
-                # The recommended item was not found in the item collection.
-                # response_intent = self._interaction_model.INTENT_DONT_KNOW  # type: ignore[attr-defined] # noqa
-                response_intent = self._interaction_model.INTENT_NEUTRAL  # type: ignore[attr-defined] # noqa
-            else:
-                # Determine user preference for the agent's recommendation.
-                # First, check if the user has already consumed the item.
-                if self._preference_model.is_item_consumed(item_id):
-                    # Currently, the user only responds by saying that they
-                    # already consumed the item. If there is a follow-up
-                    # question by the agent whether they've liked it, that
-                    # should end up in the other branch of the fork.
-                    response_intent = self._interaction_model.INTENT_ITEM_CONSUMED  # type: ignore[attr-defined] # noqa
-                else:
-                    # Get a response based on the recommendation. Currently, the
-                    # user responds immediately with a like/dislike, but it
-                    # could ask questions about the item before deciding (this
-                    # should be based on the agenda).
-                    preference = self._preference_model.get_item_preference(
-                        item_id
-                    )
-                    if preference > self._preference_model.PREFERENCE_THRESHOLD:
-                        response_intent = self._interaction_model.INTENT_LIKE  # type: ignore[attr-defined] # noqa
-                    elif (
-                        preference
-                        < -self._preference_model.PREFERENCE_THRESHOLD
-                    ):
-                        response_intent = self._interaction_model.INTENT_DISLIKE  # type: ignore[attr-defined] # noqa
-                    else:
-                        response_intent = self._interaction_model.INTENT_NEUTRAL  # type: ignore[attr-defined] # noqa
+            response_intent = self._generate_item_preference_response_intent(
+                item_id
+            )
 
         # Generating natural language response through NLG.
         response = self._nlg.generate_utterance_text(

--- a/usersimcrs/simulator/agenda_based/interaction_model.py
+++ b/usersimcrs/simulator/agenda_based/interaction_model.py
@@ -301,8 +301,8 @@ class InteractionModel:
         return items[-1]
 
     def update_agenda(self, agent_intent: Intent) -> None:
-        """Updates the agenda and determines the next user intent based on
-        agent intent.
+        """Updates the agenda and determines the next user intent based on agent
+        intent.
 
         If agent replies with an expected intent in response to the last user
         intent (based on the expected_responses mapping in the config file),

--- a/usersimcrs/simulator/agenda_based/interaction_model.py
+++ b/usersimcrs/simulator/agenda_based/interaction_model.py
@@ -300,7 +300,7 @@ class InteractionModel:
                 return items[i]
         return items[-1]
 
-    def update_agenda(self, agent_intent: Intent) -> Intent:
+    def update_agenda(self, agent_intent: Intent) -> None:
         """Updates the agenda and determines the next user intent based on
         agent intent.
 
@@ -323,6 +323,10 @@ class InteractionModel:
         ) or []
 
         logger.debug(f"Agent intent: {agent_intent}\n")
+
+        if not self._agenda:
+            self._current_intent = self.INTENT_STOP  # type: ignore[attr-defined] # noqa
+            return
 
         # If agent replies in an expected intent, then pop the next intent from
         # agenda.

--- a/usersimcrs/user_modeling/context_model.py
+++ b/usersimcrs/user_modeling/context_model.py
@@ -5,7 +5,6 @@ from typing import Dict
 
 
 class ContextModel:
-
     _DEFAULT_CONTEXT_PROBABILITIES: Dict[str, Dict[str, float]] = dict()
 
     def __init__(

--- a/usersimcrs/user_modeling/preference_model.py
+++ b/usersimcrs/user_modeling/preference_model.py
@@ -60,9 +60,8 @@ class PreferenceModel:
         historical_ratings: Ratings,
         historical_user_id: str = None,
     ) -> None:
-        """Generates a simulated user, by assigning initial preferences based
-        on historical ratings according to the specified model type (SIP or
-        PKG).
+        """Generates a simulated user, by assigning initial preferences based on
+        historical ratings according to the specified model type (SIP or PKG).
 
         Further preferences are inferred along the way as the simulated user is
         being prompted by the agent for preferences.


### PR DESCRIPTION
Try to find items match agent's utterance annotations. If there is no item matching in the collection, the preference is set to neutral (an alternative is to set the response intent to `INTENT_DONT_KNOW`).