### PR TITLE
Add dialogue state and dialogue state tracker

### DIFF
--- a/tests/dialogue_management/test_dialogue_state_tracker.py
+++ b/tests/dialogue_management/test_dialogue_state_tracker.py
@@ -17,7 +17,7 @@ def dialogue_state_tracker() -> DialogueStateTracker:
     dst = DialogueStateTracker()
 
     initial_state = dst.get_current_state()
-    assert initial_state.turn_count == 0
+    assert initial_state.utterance_count == 0
     assert initial_state.agent_dialogue_acts == []
     assert initial_state.user_dialogue_acts == []
     assert initial_state.belief_state == {}
@@ -38,7 +38,7 @@ def test_update_state_agent(
     )
 
     current_state = dialogue_state_tracker.get_current_state()
-    assert current_state.turn_count == 1
+    assert current_state.utterance_count == 1
     assert current_state.agent_dialogue_acts == [dialogue_acts]
     assert current_state.user_dialogue_acts == []
     print(current_state.belief_state)
@@ -56,10 +56,12 @@ def test_update_state_user(
         DialogueAct(Intent("request"), annotations=[Annotation("YEAR")]),
     ]
 
-    dialogue_state_tracker.update_state(dialogue_acts, DialogueParticipant.USER)
+    dialogue_state_tracker.update_state(
+        dialogue_acts, DialogueParticipant.USER
+    )
 
     current_state = dialogue_state_tracker.get_current_state()
-    assert current_state.turn_count == 2
+    assert current_state.utterance_count == 2
     assert len(current_state.agent_dialogue_acts) == 1
     assert current_state.user_dialogue_acts == [dialogue_acts]
     assert current_state.belief_state == {"GENRE": ["comedy"], "YEAR": []}

--- a/tests/dialogue_management/test_dialogue_state_tracker.py
+++ b/tests/dialogue_management/test_dialogue_state_tracker.py
@@ -18,8 +18,8 @@ def dialogue_state_tracker() -> DialogueStateTracker:
 
     initial_state = dst.get_current_state()
     assert initial_state.turn_count == 0
-    assert initial_state.agent_dacts == []
-    assert initial_state.user_dacts == []
+    assert initial_state.agent_dialogue_acts == []
+    assert initial_state.user_dialogue_acts == []
     assert initial_state.belief_state == {}
     return dst
 
@@ -29,7 +29,7 @@ def test_update_state_agent(
 ) -> None:
     """Tests dialogue state update with agent dialogue acts."""
     dialogue_acts = [
-        DialogueAct(Intent("greets")),
+        DialogueAct(Intent("greet")),
         DialogueAct(Intent("elicit"), annotations=[Annotation("GENRE")]),
     ]
 
@@ -39,9 +39,10 @@ def test_update_state_agent(
 
     current_state = dialogue_state_tracker.get_current_state()
     assert current_state.turn_count == 1
-    assert current_state.agent_dacts == [dialogue_acts]
-    assert current_state.user_dacts == []
-    assert current_state.belief_state == {"GENRE": None}
+    assert current_state.agent_dialogue_acts == [dialogue_acts]
+    assert current_state.user_dialogue_acts == []
+    print(current_state.belief_state)
+    assert current_state.belief_state == {"GENRE": []}
 
 
 def test_update_state_user(
@@ -59,6 +60,6 @@ def test_update_state_user(
 
     current_state = dialogue_state_tracker.get_current_state()
     assert current_state.turn_count == 2
-    assert len(current_state.agent_dacts) == 1
-    assert current_state.user_dacts == [dialogue_acts]
-    assert current_state.belief_state == {"GENRE": "comedy", "YEAR": None}
+    assert len(current_state.agent_dialogue_acts) == 1
+    assert current_state.user_dialogue_acts == [dialogue_acts]
+    assert current_state.belief_state == {"GENRE": ["comedy"], "YEAR": []}

--- a/tests/dialogue_management/test_dialogue_state_tracker.py
+++ b/tests/dialogue_management/test_dialogue_state_tracker.py
@@ -1,0 +1,66 @@
+"""Tests for the dialogue state tracker module."""
+
+import pytest
+from dialoguekit.core.annotation import Annotation
+from dialoguekit.core.dialogue_act import DialogueAct
+from dialoguekit.core.intent import Intent
+from dialoguekit.participant import DialogueParticipant
+
+from usersimcrs.dialogue_management.dialogue_state_tracker import (
+    DialogueStateTracker,
+)
+
+
+@pytest.fixture(scope="module")
+def dialogue_state_tracker() -> DialogueStateTracker:
+    """Fixture for the dialogue state tracker."""
+    dst = DialogueStateTracker()
+
+    initial_state = dst.get_current_state()
+    assert initial_state.turn_count == 0
+    assert initial_state.agent_dacts == []
+    assert initial_state.user_dacts == []
+    assert initial_state.belief_state == {}
+    return dst
+
+
+def test_update_state_agent(
+    dialogue_state_tracker: DialogueStateTracker,
+) -> None:
+    """Tests dialogue state update with agent dialogue acts."""
+    dialogue_acts = [
+        DialogueAct(Intent("greets")),
+        DialogueAct(Intent("elicit"), annotations=[Annotation("GENRE")]),
+    ]
+
+    dialogue_state_tracker.update_state(
+        dialogue_acts, DialogueParticipant.AGENT
+    )
+
+    current_state = dialogue_state_tracker.get_current_state()
+    assert current_state.turn_count == 1
+    assert current_state.agent_dacts == [dialogue_acts]
+    assert current_state.user_dacts == []
+    assert current_state.belief_state == {"GENRE": None}
+
+
+def test_update_state_user(
+    dialogue_state_tracker: DialogueStateTracker,
+) -> None:
+    """Tests dialogue state update with user dialogue acts."""
+    dialogue_acts = [
+        DialogueAct(
+            Intent("inform"), annotations=[Annotation("GENRE", "comedy")]
+        ),
+        DialogueAct(Intent("request"), annotations=[Annotation("YEAR")]),
+    ]
+
+    dialogue_state_tracker.update_state(
+        dialogue_acts, DialogueParticipant.USER
+    )
+
+    current_state = dialogue_state_tracker.get_current_state()
+    assert current_state.turn_count == 2
+    assert len(current_state.agent_dacts) == 1
+    assert current_state.user_dacts == [dialogue_acts]
+    assert current_state.belief_state == {"GENRE": "comedy", "YEAR": None}

--- a/tests/dialogue_management/test_dialogue_state_tracker.py
+++ b/tests/dialogue_management/test_dialogue_state_tracker.py
@@ -56,9 +56,7 @@ def test_update_state_user(
         DialogueAct(Intent("request"), annotations=[Annotation("YEAR")]),
     ]
 
-    dialogue_state_tracker.update_state(
-        dialogue_acts, DialogueParticipant.USER
-    )
+    dialogue_state_tracker.update_state(dialogue_acts, DialogueParticipant.USER)
 
     current_state = dialogue_state_tracker.get_current_state()
     assert current_state.utterance_count == 2

--- a/tests/dialogue_management/test_dialogue_state_tracker.py
+++ b/tests/dialogue_management/test_dialogue_state_tracker.py
@@ -55,9 +55,7 @@ def test_update_state_user(
         DialogueAct(Intent("request"), annotations=[Annotation("YEAR")]),
     ]
 
-    dialogue_state_tracker.update_state(
-        dialogue_acts, DialogueParticipant.USER
-    )
+    dialogue_state_tracker.update_state(dialogue_acts, DialogueParticipant.USER)
 
     current_state = dialogue_state_tracker.get_current_state()
     assert current_state.turn_count == 2

--- a/usersimcrs/dialogue_management/dialogue_state.py
+++ b/usersimcrs/dialogue_management/dialogue_state.py
@@ -1,7 +1,6 @@
 """Representation of the dialogue state.
 
-The dialogue state includes the turn (i.e., an exchange of utterances between
-the user and the agent) count, a list of dialogue acts per utterance for both
+The dialogue state includes the number of utterance, a list of dialogue acts per utterance for both
 the agent and the user, and the belief state. The belief state is a dictionary
 that holds for each slot (key) the values provided by the user.
 """
@@ -18,13 +17,13 @@ class DialogueState:
     """Dialogue state.
 
     Attributes:
-        turn_count: Turn count.
-        agent_dacts: List of dialogue acts per turn for the agent.
-        user_dacts: List of dialogue acts per turn for the user.
+        utterance_count: Utterance count.
+        agent_dialogue_acts: List of dialogue acts per turn for the agent.
+        user_dialogue_acts: List of dialogue acts per turn for the user.
         belief_state: Belief state.
     """
 
-    turn_count: int = 0
+    utterance_count: int = 0
     agent_dialogue_acts: List[List[DialogueAct]] = field(default_factory=list)
     user_dialogue_acts: List[List[DialogueAct]] = field(default_factory=list)
     belief_state: DefaultDict[str, List[str]] = field(

--- a/usersimcrs/dialogue_management/dialogue_state.py
+++ b/usersimcrs/dialogue_management/dialogue_state.py
@@ -1,8 +1,9 @@
 """Representation of the dialogue state.
 
-The dialogue state includes the turn count, a list of dialogue acts per turn for
-both the agent and the user, and the belief state. The belief state is a
-dictionary that maps slot names to slot values.
+The dialogue state includes the turn (i.e., an exchange of utterances between
+the user and the agent) count, a list of dialogue acts per utterance for both
+the agent and the user, and the belief state. The belief state is a dictionary
+that holds for each slot (key) the values provided by the user.
 """
 
 from collections import defaultdict
@@ -24,8 +25,8 @@ class DialogueState:
     """
 
     turn_count: int = 0
-    agent_dacts: List[List[DialogueAct]] = field(default_factory=list)
-    user_dacts: List[List[DialogueAct]] = field(default_factory=list)
-    belief_state: DefaultDict[str, str] = field(
-        default_factory=lambda: defaultdict(str)
+    agent_dialogue_acts: List[List[DialogueAct]] = field(default_factory=list)
+    user_dialogue_acts: List[List[DialogueAct]] = field(default_factory=list)
+    belief_state: DefaultDict[str, List[str]] = field(
+        default_factory=lambda: defaultdict(list)
     )

--- a/usersimcrs/dialogue_management/dialogue_state.py
+++ b/usersimcrs/dialogue_management/dialogue_state.py
@@ -1,7 +1,7 @@
 """Representation of the dialogue state.
 
-The dialogue state includes the turn count, a list of dialogue acts per turn
-for both the agent and the user, and the belief state. The belief state is a
+The dialogue state includes the turn count, a list of dialogue acts per turn for
+both the agent and the user, and the belief state. The belief state is a
 dictionary that maps slot names to slot values.
 """
 

--- a/usersimcrs/dialogue_management/dialogue_state.py
+++ b/usersimcrs/dialogue_management/dialogue_state.py
@@ -1,0 +1,31 @@
+"""Representation of the dialogue state.
+
+The dialogue state includes the turn count, a list of dialogue acts per turn
+for both the agent and the user, and the belief state. The belief state is a
+dictionary that maps slot names to slot values.
+"""
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import DefaultDict, List
+
+from dialoguekit.core.dialogue_act import DialogueAct
+
+
+@dataclass
+class DialogueState:
+    """Dialogue state.
+
+    Attributes:
+        turn_count: Turn count.
+        agent_dacts: List of dialogue acts per turn for the agent.
+        user_dacts: List of dialogue acts per turn for the user.
+        belief_state: Belief state.
+    """
+
+    turn_count: int = 0
+    agent_dacts: List[List[DialogueAct]] = field(default_factory=list)
+    user_dacts: List[List[DialogueAct]] = field(default_factory=list)
+    belief_state: DefaultDict[str, str] = field(
+        default_factory=lambda: defaultdict(str)
+    )

--- a/usersimcrs/dialogue_management/dialogue_state.py
+++ b/usersimcrs/dialogue_management/dialogue_state.py
@@ -1,8 +1,9 @@
 """Representation of the dialogue state.
 
-The dialogue state includes the number of utterance, a list of dialogue acts per utterance for both
-the agent and the user, and the belief state. The belief state is a dictionary
-that holds for each slot (key) the values provided by the user.
+The dialogue state includes the number of utterances, a list of dialogue acts
+per utterance for both the agent and the user, and the belief state. The belief
+state is a dictionary that holds for each slot (key) the values provided by the
+user.
 """
 
 from collections import defaultdict

--- a/usersimcrs/dialogue_management/dialogue_state_tracker.py
+++ b/usersimcrs/dialogue_management/dialogue_state_tracker.py
@@ -38,6 +38,7 @@ class DialogueStateTracker:
             self._dialogue_state.agent_dacts.append(dialogue_acts)
 
         self.update_belief_state(dialogue_acts)
+        self._dialogue_state.turn_count += 1
 
     def update_belief_state(self, dialogue_acts: List[DialogueAct]) -> None:
         """Updates the belief state based on the dialogue acts.

--- a/usersimcrs/dialogue_management/dialogue_state_tracker.py
+++ b/usersimcrs/dialogue_management/dialogue_state_tracker.py
@@ -33,9 +33,9 @@ class DialogueStateTracker:
             participant: Dialogue participant.
         """
         if participant == DialogueParticipant.USER:
-            self._dialogue_state.user_dacts.append(dialogue_acts)
+            self._dialogue_state.user_dialogue_acts.append(dialogue_acts)
         else:
-            self._dialogue_state.agent_dacts.append(dialogue_acts)
+            self._dialogue_state.agent_dialogue_acts.append(dialogue_acts)
 
         self.update_belief_state(dialogue_acts)
         self._dialogue_state.turn_count += 1
@@ -48,9 +48,12 @@ class DialogueStateTracker:
         """
         for dialogue_act in dialogue_acts:
             for annotation in dialogue_act.annotations:
-                self._dialogue_state.belief_state[
-                    annotation.slot
-                ] = annotation.value
+                if annotation.value:
+                    self._dialogue_state.belief_state[annotation.slot].append(
+                        annotation.value
+                    )
+                else:
+                    self._dialogue_state.belief_state[annotation.slot] = []
 
     def reset_state(self) -> None:
         """Resets the dialogue state."""

--- a/usersimcrs/dialogue_management/dialogue_state_tracker.py
+++ b/usersimcrs/dialogue_management/dialogue_state_tracker.py
@@ -38,7 +38,7 @@ class DialogueStateTracker:
             self._dialogue_state.agent_dialogue_acts.append(dialogue_acts)
 
         self.update_belief_state(dialogue_acts)
-        self._dialogue_state.turn_count += 1
+        self._dialogue_state.utterance_count += 1
 
     def update_belief_state(self, dialogue_acts: List[DialogueAct]) -> None:
         """Updates the belief state based on the dialogue acts.

--- a/usersimcrs/dialogue_management/dialogue_state_tracker.py
+++ b/usersimcrs/dialogue_management/dialogue_state_tracker.py
@@ -1,0 +1,56 @@
+"""Interface for dialogue state tracking."""
+
+from typing import List
+
+from dialoguekit.core.dialogue_act import DialogueAct
+from dialoguekit.participant import DialogueParticipant
+
+from usersimcrs.dialogue_management.dialogue_state import DialogueState
+
+
+class DialogueStateTracker:
+    def __init__(self) -> None:
+        """Initializes the dialogue state tracker."""
+        self._dialogue_state = DialogueState()
+
+    def get_current_state(self) -> DialogueState:
+        """Returns the current dialogue state.
+
+        Returns:
+            DialogueState.
+        """
+        return self._dialogue_state
+
+    def update_state(
+        self,
+        dialogue_acts: List[DialogueAct],
+        participant: DialogueParticipant,
+    ) -> None:
+        """Updates the dialogue state based on the dialogue acts.
+
+        Args:
+            dialogue_acts: Dialogue acts.
+            participant: Dialogue participant.
+        """
+        if participant == DialogueParticipant.USER:
+            self._dialogue_state.user_dacts.append(dialogue_acts)
+        else:
+            self._dialogue_state.agent_dacts.append(dialogue_acts)
+
+        self.update_belief_state(dialogue_acts)
+
+    def update_belief_state(self, dialogue_acts: List[DialogueAct]) -> None:
+        """Updates the belief state based on the dialogue acts.
+
+        Args:
+            dialogue_acts: Dialogue acts.
+        """
+        for dialogue_act in dialogue_acts:
+            for annotation in dialogue_act.annotations:
+                self._dialogue_state.belief_state[
+                    annotation.slot
+                ] = annotation.value
+
+    def reset_state(self) -> None:
+        """Resets the dialogue state."""
+        self._dialogue_state = DialogueState()


### PR DESCRIPTION
This PR add components for dialogue management. Information related to the dialogue state are needed to prepare the input feature for the transformer-based user simulator.

## What's changed?

* Add classes for dialogue state and dialogue state tracker
* Add tests for new classes

Fixes #163 