### PR TITLE
Feature/173-Implement-creation-of-transition-matrices-in-interaction-model

### DIFF
--- a/tests/data/annotated_dialogues.json
+++ b/tests/data/annotated_dialogues.json
@@ -93,8 +93,7 @@
                 "participant": "USER",
                 "dialogue_acts": [
                     {
-                        "intent": "DISCLOSE.NON-DISCLOSE",
-                        "slot_values": []
+                        "intent": "DISCLOSE.NON-DISCLOSE"
                     }
                 ],
                 "utterance": "Utterance 1"
@@ -113,12 +112,10 @@
                 "participant": "USER",
                 "dialogue_acts": [
                     {
-                        "intent": "Intent-B",
-                        "slot_values": []
+                        "intent": "Intent-B"
                     },
                     {
-                        "intent": "Intent-A",
-                        "slot_values": []
+                        "intent": "Intent-A"
                     }
                 ],
                 "utterance": "Utterance 3"
@@ -127,8 +124,7 @@
                 "participant": "AGENT",
                 "dialogue_acts": [
                     {
-                        "intent": "INQUIRE",
-                        "slot_values": []
+                        "intent": "INQUIRE"
                     }
                 ],
                 "utterance": "Utterance 4"
@@ -137,8 +133,7 @@
                 "participant": "USER",
                 "dialogue_acts": [
                     {
-                        "intent": "Intent-A",
-                        "slot_values": []
+                        "intent": "Intent-A"
                     }
                 ],
                 "utterance": "Utterance 5"
@@ -147,8 +142,7 @@
                 "participant": "AGENT",
                 "dialogue_acts": [
                     {
-                        "intent": "INQUIRE",
-                        "slot_values": []
+                        "intent": "INQUIRE"
                     }
                 ],
                 "utterance": "Utterance 6"
@@ -157,8 +151,7 @@
                 "participant": "USER",
                 "dialogue_acts": [
                     {
-                        "intent": "Intent-C",
-                        "slot_values": []
+                        "intent": "Intent-C"
                     }
                 ],
                 "utterance": "Utterance 7"
@@ -180,8 +173,7 @@
                 "participant": "USER",
                 "dialogue_acts": [
                     {
-                        "intent": "DISCLOSE.NON-DISCLOSE",
-                        "slot_values": []
+                        "intent": "DISCLOSE.NON-DISCLOSE"
                     }
                 ],
                 "utterance": "Utterance 1"
@@ -190,8 +182,7 @@
                 "participant": "AGENT",
                 "dialogue_acts": [
                     {
-                        "intent": "INQUIRE",
-                        "slot_values": []
+                        "intent": "INQUIRE"
                     }
                 ],
                 "utterance": "Utterance 2"
@@ -200,8 +191,7 @@
                 "participant": "USER",
                 "dialogue_acts": [
                     {
-                        "intent": "Intent-A",
-                        "slot_values": []
+                        "intent": "Intent-A"
                     }
                 ],
                 "utterance": "Utterance 3"
@@ -210,8 +200,7 @@
                 "participant": "AGENT",
                 "dialogue_acts": [
                     {
-                        "intent": "INQUIRE",
-                        "slot_values": []
+                        "intent": "INQUIRE"
                     }
                 ],
                 "utterance": "Utterance 4"
@@ -220,8 +209,7 @@
                 "participant": "USER",
                 "dialogue_acts": [
                     {
-                        "intent": "Intent-C",
-                        "slot_values": []
+                        "intent": "Intent-C"
                     }
                 ],
                 "utterance": "Utterance 5"
@@ -230,8 +218,7 @@
                 "participant": "AGENT",
                 "dialogue_acts": [
                     {
-                        "intent": "INQUIRE",
-                        "slot_values": []
+                        "intent": "INQUIRE"
                     }
                 ],
                 "utterance": "Utterance 6"
@@ -240,8 +227,7 @@
                 "participant": "USER",
                 "dialogue_acts": [
                     {
-                        "intent": "Intent-C",
-                        "slot_values": []
+                        "intent": "Intent-C"
                     }
                 ],
                 "utterance": "Utterance 7"

--- a/tests/data/annotated_dialogues.json
+++ b/tests/data/annotated_dialogues.json
@@ -4,37 +4,76 @@
         "conversation": [
             {
                 "participant": "USER",
-                "intent": "DISCLOSE.NON-DISCLOSE",
+                "dialogue_acts": [
+                    {
+                        "intent": "DISCLOSE.NON-DISCLOSE",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 1"
             },
             {
                 "participant": "AGENT",
-                "intent": "INQUIRE",
+                "dialogue_acts": [
+                    {
+                        "intent": "ELICIT",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 2"
             },
             {
                 "participant": "USER",
-                "intent": "Intent-A",
+                "dialogue_acts": [
+                    {
+                        "intent": "Intent-A",
+                        "slot_values": []
+                    },
+                    {
+                        "intent": "Intent-B",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 3"
             },
             {
                 "participant": "AGENT",
-                "intent": "INQUIRE",
+                "dialogue_acts": [
+                    {
+                        "intent": "INQUIRE",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 4"
             },
             {
                 "participant": "USER",
-                "intent": "Intent-B",
+                "dialogue_acts": [
+                    {
+                        "intent": "Intent-B",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 5"
             },
             {
                 "participant": "AGENT",
-                "intent": "INQUIRE",
+                "dialogue_acts": [
+                    {
+                        "intent": "ELICIT",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 6"
             },
             {
                 "participant": "USER",
-                "intent": "Intent-C",
+                "dialogue_acts": [
+                    {
+                        "intent": "Intent-C",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 7"
             }
         ],
@@ -52,37 +91,76 @@
         "conversation": [
             {
                 "participant": "USER",
-                "intent": "DISCLOSE.NON-DISCLOSE",
+                "dialogue_acts": [
+                    {
+                        "intent": "DISCLOSE.NON-DISCLOSE",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 1"
             },
             {
                 "participant": "AGENT",
-                "intent": "INQUIRE",
+                "dialogue_acts": [
+                    {
+                        "intent": "INQUIRE",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 2"
             },
             {
                 "participant": "USER",
-                "intent": "Intent-A",
+                "dialogue_acts": [
+                    {
+                        "intent": "Intent-B",
+                        "slot_values": []
+                    },
+                    {
+                        "intent": "Intent-A",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 3"
             },
             {
                 "participant": "AGENT",
-                "intent": "INQUIRE",
+                "dialogue_acts": [
+                    {
+                        "intent": "INQUIRE",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 4"
             },
             {
                 "participant": "USER",
-                "intent": "Intent-A",
+                "dialogue_acts": [
+                    {
+                        "intent": "Intent-A",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 5"
             },
             {
                 "participant": "AGENT",
-                "intent": "INQUIRE",
+                "dialogue_acts": [
+                    {
+                        "intent": "INQUIRE",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 6"
             },
             {
                 "participant": "USER",
-                "intent": "Intent-C",
+                "dialogue_acts": [
+                    {
+                        "intent": "Intent-C",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 7"
             }
         ],
@@ -100,37 +178,72 @@
         "conversation": [
             {
                 "participant": "USER",
-                "intent": "DISCLOSE.NON-DISCLOSE",
+                "dialogue_acts": [
+                    {
+                        "intent": "DISCLOSE.NON-DISCLOSE",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 1"
             },
             {
                 "participant": "AGENT",
-                "intent": "INQUIRE",
+                "dialogue_acts": [
+                    {
+                        "intent": "INQUIRE",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 2"
             },
             {
                 "participant": "USER",
-                "intent": "Intent-A",
+                "dialogue_acts": [
+                    {
+                        "intent": "Intent-A",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 3"
             },
             {
                 "participant": "AGENT",
-                "intent": "INQUIRE",
+                "dialogue_acts": [
+                    {
+                        "intent": "INQUIRE",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 4"
             },
             {
                 "participant": "USER",
-                "intent": "Intent-C",
+                "dialogue_acts": [
+                    {
+                        "intent": "Intent-C",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 5"
             },
             {
                 "participant": "AGENT",
-                "intent": "INQUIRE",
+                "dialogue_acts": [
+                    {
+                        "intent": "INQUIRE",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 6"
             },
             {
                 "participant": "USER",
-                "intent": "Intent-C",
+                "dialogue_acts": [
+                    {
+                        "intent": "Intent-C",
+                        "slot_values": []
+                    }
+                ],
                 "utterance": "Utterance 7"
             }
         ],

--- a/tests/data/interaction_models/crs_v1.yaml
+++ b/tests/data/interaction_models/crs_v1.yaml
@@ -107,6 +107,10 @@ agent_set_retrieval:
   - REVEAL.SIMILAR
   - REVEAL.NONE
 
+# List of agent intents (including sub-intents) that are for inquiries.
+agent_inquire_intents:
+  - INQUIRE
+
 # Reward settings
 REWARD:
   full_set_points: 20

--- a/tests/simulator/agenda_based/test_interaction_model.py
+++ b/tests/simulator/agenda_based/test_interaction_model.py
@@ -122,6 +122,8 @@ def test_sample_next_user_dialogue_acts(
     user_dialogue_acts = im_crsv1._sample_next_user_dialogue_acts(
         information_need, agent_dialogue_acts
     )
+    # The sampling is non-deterministic, so different outcomes are possible.
+    # Here we check for the two possible outcomes.
     assert user_dialogue_acts == [
         DialogueAct(Intent("Intent-A")),
         DialogueAct(Intent("Intent-B")),

--- a/tests/simulator/agenda_based/test_interaction_model.py
+++ b/tests/simulator/agenda_based/test_interaction_model.py
@@ -3,6 +3,7 @@
 import pytest
 
 from dialoguekit.core.dialogue_act import DialogueAct
+from dialoguekit.core.intent import Intent
 from dialoguekit.core.slot_value_annotation import SlotValueAnnotation
 from dialoguekit.utils.dialogue_reader import json_to_dialogues
 from usersimcrs.core.information_need import InformationNeed
@@ -32,6 +33,15 @@ def im_crsv1(
     return im
 
 
+def test_initialize_with_error(domain: SimulationDomain) -> None:
+    with pytest.raises(FileNotFoundError):
+        InteractionModel(
+            "tests/data/interaction_models/invalid_file.yaml",
+            domain,
+            ANNOTATED_CONVERSATIONS,
+        )
+
+
 def test_initialize_agenda(
     im_crsv1: InteractionModel, information_need: InformationNeed
 ) -> None:
@@ -45,6 +55,19 @@ def test_initialize_agenda(
     assert im_crsv1.agenda.stack[-1].intent == im_crsv1.INTENT_STOP
 
 
+def test_initialize_transition_matrices(im_crsv1: InteractionModel) -> None:
+    (
+        transition_single_intent,
+        transition_compound_intent,
+    ) = im_crsv1.initialize_transition_matrices(ANNOTATED_CONVERSATIONS)
+
+    assert transition_single_intent.shape == (2, 3)
+    assert transition_compound_intent.shape == (2, 4)
+
+    assert transition_compound_intent.loc["ELICIT", "Intent-A_Intent-B"] == 0.5
+    assert transition_single_intent.loc["INQUIRE", "Intent-A"] == 3 / 8
+
+
 def test_get_next_dialogue_acts(im_crsv1: InteractionModel) -> None:
     dialogue_acts = im_crsv1.get_next_dialogue_acts(3)
     assert len(dialogue_acts) == 3
@@ -54,3 +77,52 @@ def test_get_next_dialogue_acts(im_crsv1: InteractionModel) -> None:
         im_crsv1.INTENT_DISCLOSE,
         [SlotValueAnnotation("DIRECTOR", "Steven Spielberg")],
     )
+
+
+def test_intent_types(im_crsv1: InteractionModel) -> None:
+    """Tests methods checking the type of intents."""
+    assert im_crsv1.is_agent_intent_elicit(Intent("ELICIT")) is False
+    assert im_crsv1.is_agent_intent_inquire(Intent("INQUIRE")) is True
+    assert im_crsv1.is_agent_intent_set_retrieval(Intent("REVEAL")) is True
+
+
+def test_is_transition_allowed(monkeypatch, im_crsv1: InteractionModel) -> None:
+    monkeypatch.setattr(
+        im_crsv1, "_current_dialogue_acts", [DialogueAct(Intent("DISCLOSE"))]
+    )
+    dialogue_acts_allowed = [
+        DialogueAct(Intent("INQUIRE")),
+        DialogueAct(Intent("REVEAL")),
+    ]
+    dialogue_acts_not_allowed = [DialogueAct(Intent("END"))]
+
+    assert im_crsv1._is_transition_allowed(dialogue_acts_allowed) is True
+    assert im_crsv1._is_transition_allowed(dialogue_acts_not_allowed) is False
+
+
+def test_sample_next_user_dialogue_acts(
+    caplog, im_crsv1: InteractionModel, information_need: InformationNeed
+) -> None:
+    agent_dialogue_acts = [
+        DialogueAct(Intent("GREETING")),
+        DialogueAct(Intent("ELICIT")),
+    ]
+    user_dialogue_acts = im_crsv1._sample_next_user_dialogue_acts(
+        information_need, agent_dialogue_acts
+    )
+    assert len(user_dialogue_acts) == 1
+    assert (
+        "Transition matrix does not contain agent intent: GREETING"
+        in caplog.text
+    )
+
+    agent_dialogue_acts = [
+        DialogueAct(Intent("ELICIT")),
+    ]
+    user_dialogue_acts = im_crsv1._sample_next_user_dialogue_acts(
+        information_need, agent_dialogue_acts
+    )
+    assert user_dialogue_acts == [
+        DialogueAct(Intent("Intent-A")),
+        DialogueAct(Intent("Intent-B")),
+    ] or user_dialogue_acts == [DialogueAct(Intent("Intent-C"))]

--- a/usersimcrs/simulator/agenda_based/interaction_model.py
+++ b/usersimcrs/simulator/agenda_based/interaction_model.py
@@ -7,16 +7,19 @@ between dialogue acts based on their intents and updating the agenda.
 import logging
 import os
 import random
-from typing import List, Tuple
+from collections import defaultdict
+from typing import DefaultDict, List, Tuple
 
 import pandas as pd
 import yaml
 from nltk.stem import WordNetLemmatizer
 
+from dialoguekit.core.annotated_utterance import AnnotatedUtterance
 from dialoguekit.core.dialogue import Dialogue
 from dialoguekit.core.dialogue_act import DialogueAct
 from dialoguekit.core.intent import Intent
 from dialoguekit.core.slot_value_annotation import SlotValueAnnotation
+from dialoguekit.participant import DialogueParticipant
 from usersimcrs.core.information_need import InformationNeed
 from usersimcrs.core.simulation_domain import SimulationDomain
 from usersimcrs.dialogue_management.dialogue_state_tracker import (
@@ -116,18 +119,95 @@ class InteractionModel:
         The compound intent transition matrix will be:
         {GREETING, REQUEST} -> INFORM : 1
 
+        Note that the compound intent may also include single intents, in case
+        an utterance has a single dialogue act.
+
         Args:
             annotated_conversations: Annotated conversations.
 
         Returns:
             Transition matrices.
         """
-        transition_matrix_single = pd.DataFrame()
-        transition_matrix_compound = pd.DataFrame()
+        single_intent_distribution: DefaultDict[
+            str, DefaultDict[str, int]
+        ] = defaultdict(lambda: defaultdict(int))
+        compound_intent_distribution: DefaultDict[
+            str, DefaultDict[str, int]
+        ] = defaultdict(lambda: defaultdict(int))
 
-        # TODO: Implement transition matrices creation
-        # See: https://github.com/iai-group/UserSimCRS/issues/173
+        agent_user_interactions = self._get_agent_user_interactions(
+            annotated_conversations
+        )
+        for agent_dialogue_acts, user_dialogue_acts in agent_user_interactions:
+            compound_agent_intent = "_".join(
+                sorted({da.intent.label for da in agent_dialogue_acts})
+            )
+            compound_user_intent = "_".join(
+                sorted({da.intent.label for da in user_dialogue_acts})
+            )
+            compound_intent_distribution[compound_agent_intent][
+                compound_user_intent
+            ] += 1
+            for agent_dialogue_act in agent_dialogue_acts:
+                agent_intent = agent_dialogue_act.intent.label
+                for user_dialogue_act in user_dialogue_acts:
+                    user_intent = user_dialogue_act.intent.label
+                    single_intent_distribution[agent_intent][user_intent] += 1
+
+        transition_matrix_single = pd.DataFrame.from_dict(
+            single_intent_distribution, orient="index"
+        ).fillna(0)
+        transition_matrix_compound = pd.DataFrame.from_dict(
+            compound_intent_distribution, orient="index"
+        ).fillna(0)
+        # Normalize the transition matrices.
+        transition_matrix_single = transition_matrix_single.div(
+            transition_matrix_single.sum(axis=1), axis=0
+        )
+        transition_matrix_compound = transition_matrix_compound.div(
+            transition_matrix_compound.sum(axis=1), axis=0
+        )
+
         return transition_matrix_single, transition_matrix_compound
+
+    def _get_agent_user_interactions(
+        self, annotated_conversations: List[Dialogue]
+    ) -> List[Tuple[List[DialogueAct], List[DialogueAct]]]:
+        """Returns agent-user interactions from annotated conversations.
+
+        Args:
+            annotated_conversations: Annotated conversations.
+
+        Returns:
+            Agent-user interactions.
+        """
+        agent_user_interactions = []
+        for conversation in annotated_conversations:
+            agent_dialogue_acts = []
+            user_dialogue_acts = []
+            for utterance in conversation.utterances:
+                assert isinstance(utterance, AnnotatedUtterance), TypeError(
+                    "AnnotatedUtterance expected, but found "
+                    f"{type(utterance)}"
+                )
+                if utterance.participant == DialogueParticipant.AGENT:
+                    agent_dialogue_acts.extend(utterance.dialogue_acts)
+                elif (
+                    not agent_dialogue_acts
+                    and utterance.participant == DialogueParticipant.USER
+                ):
+                    # Skip user utterances that come before the agent's first
+                    # utterance.
+                    continue
+                else:
+                    user_dialogue_acts.extend(utterance.dialogue_acts)
+                if agent_dialogue_acts and user_dialogue_acts:
+                    agent_user_interactions.append(
+                        (agent_dialogue_acts, user_dialogue_acts)
+                    )
+                    agent_dialogue_acts = []
+                    user_dialogue_acts = []
+        return agent_user_interactions
 
     def initialize_agenda(self, information_need: InformationNeed):
         """Initializes user agenda.
@@ -478,7 +558,7 @@ class InteractionModel:
         self,
         information_need: InformationNeed,
         agent_dialogue_acts: List[DialogueAct],
-    ):
+    ) -> List[DialogueAct]:
         """Samples next user dialogue acts based on a probability distribution.
 
         Args:
@@ -490,6 +570,76 @@ class InteractionModel:
         """
         # Check if the agent's dialogue acts are in the compound transition
         # matrix. If not, we consider the single transition matrix.
+        compound_agent_intent = "_".join(
+            sorted({da.intent.label for da in agent_dialogue_acts})
+        )
 
-        # TODO: Implement this method
-        pass
+        sampled_user_intents = []
+
+        if compound_agent_intent in self.transition_matrix_compound.index:
+            # Sample from the row of the compound transition matrix.
+            user_intents = self.transition_matrix_compound.loc[
+                compound_agent_intent
+            ]
+            sampled_user_intents.extend(
+                [
+                    Intent(intent)
+                    for intent in user_intents.sample(n=1, weights=user_intents)
+                    .index[0]
+                    .split("_")
+                ]
+            )
+        else:
+            # For each agent's dialogue act, we sample from the row of the
+            # single intent transition matrix.
+            for agent_dialogue_act in agent_dialogue_acts:
+                user_intents = self.transition_matrix_single.loc[
+                    agent_dialogue_act.intent.label
+                ]
+                sampled_user_intents.append(
+                    Intent(
+                        user_intents.sample(n=1, weights=user_intents).index[0]
+                    )
+                )
+
+        # Generate dialogue acts based on the sampled intents, the annotations
+        # are generated based on the information need and belief state. Note
+        # that only simple cases (disclose and inquire) are considered here.
+        user_dialogue_acts = []
+        current_belief_state = (
+            self.dialogue_state_tracker.get_current_state().belief_state
+        )
+        for sampled_intent in sampled_user_intents:
+            if sampled_intent == self.INTENT_DISCLOSE:  # type: ignore[attr-defined] # noqa
+                # Check if there is a slot from the information need that is
+                # not fulfilled in the belief state, else choose a random slot
+                # value from the constraints.
+                slot = None
+                value = None
+                for belief_state_slot in current_belief_state.keys():
+                    if belief_state_slot not in information_need.constraints:
+                        slot = belief_state_slot
+                        value = information_need.get_constraint_value(slot)
+                        break
+
+                if slot is None:
+                    slot, value = random.choice(
+                        list(information_need.constraints.items())
+                    )
+
+                user_dialogue_acts.append(
+                    DialogueAct(
+                        sampled_intent, [SlotValueAnnotation(slot, value)]
+                    )
+                )
+            elif sampled_intent == self.INTENT_INQUIRE:  # type: ignore[attr-defined] # noqa
+                slot = random.choice(information_need.get_requestable_slots())
+                if not slot:
+                    slot = random.choice(self._domain.get_requestable_slots())
+                user_dialogue_acts.append(
+                    DialogueAct(sampled_intent, [SlotValueAnnotation(slot)])
+                )
+            else:
+                user_dialogue_acts.append(DialogueAct(sampled_intent))
+
+        return user_dialogue_acts

--- a/usersimcrs/simulator/agenda_based/interaction_model.py
+++ b/usersimcrs/simulator/agenda_based/interaction_model.py
@@ -117,7 +117,7 @@ class InteractionModel:
         GREETING -> INFORM : 1
         REQUEST -> INFORM : 1
         The compound intent transition matrix will be:
-        {GREETING, REQUEST} -> INFORM : 1
+        GREETING_REQUEST -> INFORM : 1
 
         Note that the compound intent may also include single intents, in case
         an utterance has a single dialogue act.
@@ -139,11 +139,11 @@ class InteractionModel:
             annotated_conversations
         )
         for agent_dialogue_acts, user_dialogue_acts in agent_user_interactions:
-            compound_agent_intent = "_".join(
-                sorted({da.intent.label for da in agent_dialogue_acts})
+            compound_agent_intent = self._get_compound_intent_label(
+                agent_dialogue_acts
             )
-            compound_user_intent = "_".join(
-                sorted({da.intent.label for da in user_dialogue_acts})
+            compound_user_intent = self._get_compound_intent_label(
+                user_dialogue_acts
             )
             compound_intent_distribution[compound_agent_intent][
                 compound_user_intent
@@ -612,6 +612,22 @@ class InteractionModel:
 
         return user_dialogue_acts
 
+    def _get_compound_intent_label(
+        self, dialogue_acts: List[DialogueAct]
+    ) -> str:
+        """Returns the compound intent label.
+
+        The compound intent label is formed by concatenating alphabetically
+        sorted single intent labels with underscore as separator.
+
+        Args:
+            dialogue_acts: Dialogue acts.
+
+        Returns:
+            Compound intent label.
+        """
+        return "_".join(sorted({da.intent.label for da in dialogue_acts}))
+
     def _sample_user_intents(self, agent_dialogue_acts: List[DialogueAct]):
         """Samples user intents based on the agent's dialogue acts.
 
@@ -624,8 +640,8 @@ class InteractionModel:
         Returns:
             List of sampled user intents.
         """
-        compound_agent_intent = "_".join(
-            sorted({da.intent.label for da in agent_dialogue_acts})
+        compound_agent_intent = self._get_compound_intent_label(
+            agent_dialogue_acts
         )
         sampled_user_intents = []
 


### PR DESCRIPTION
## What's changed?

* Implement `initialize_transition_matrices` and  `_sample_next_user_dialogue_acts`
* Add tests for interaction model

Note that the compound intent matrix may also contain single intents in case some utterances have a single dialogue act. In a simple case (i.e., low complexity), it is expected that the compound and single intent transition matrices are similar even redundant in extreme case.

Depends on DialogueKit's PR [#261](https://github.com/iai-group/DialogueKit/pull/261)
Fixes #173 