### PR TITLE
Add dual prompt LLM US

### DIFF
--- a/tests/data/domains/movies.yaml
+++ b/tests/data/domains/movies.yaml
@@ -20,7 +20,6 @@ requestable_slots:
   - DIRECTOR
 
 informable_slots:
-  - TITLE
   - GENRE
   - ACTOR
   - KEYWORD

--- a/tests/simulator/llm/test_stop_prompt.py
+++ b/tests/simulator/llm/test_stop_prompt.py
@@ -1,0 +1,40 @@
+"""Tests stop prompt."""
+
+import pytest
+
+from usersimcrs.core.information_need import InformationNeed
+from usersimcrs.simulator.llm.prompt.stop_prompt import (
+    DEFAULT_STOP_DEFINITION,
+    StopPrompt,
+)
+
+
+@pytest.fixture
+def prompt(information_need: InformationNeed) -> StopPrompt:
+    """Returns a Prompt object."""
+    return StopPrompt(information_need, "item")
+
+
+def test_build_new_prompt(prompt: StopPrompt) -> None:
+    """Tests the build_new_prompt method."""
+    stringified_requirements = (
+        "\nREQUIREMENTS: You are looking for a item with the following "
+        "characteristics: genre=Comedy, director=Steven Spielberg and want to "
+        "know the following information about it: plot, rating.\nHISTORY:\n"
+    )
+
+    assert prompt.build_new_prompt() == (
+        DEFAULT_STOP_DEFINITION + stringified_requirements
+    )
+
+
+def test_prompt_text(prompt: StopPrompt) -> None:
+    """Tests the prompt_text property."""
+    initial_prompt = (
+        f"{DEFAULT_STOP_DEFINITION}\nREQUIREMENTS: You are looking "
+        "for a item with the following characteristics: genre=Comedy, "
+        "director=Steven Spielberg and want to know the following information "
+        "about it: plot, rating.\nHISTORY:\n"
+    )
+
+    assert prompt.prompt_text == initial_prompt + "\n\nCONTINUE: "

--- a/tests/simulator/llm/test_utterance_generation_prompt.py
+++ b/tests/simulator/llm/test_utterance_generation_prompt.py
@@ -1,11 +1,14 @@
-"""Tests prompt."""
+"""Tests utterance generation prompt."""
 
 import pytest
+
 from dialoguekit.core import Utterance
 from dialoguekit.participant import DialogueParticipant
-
 from usersimcrs.core.information_need import InformationNeed
-from usersimcrs.simulator.llm.prompt import DEFAULT_TASK_DEFINITION, Prompt
+from usersimcrs.simulator.llm.prompt.utterance_generation_prompt import (
+    DEFAULT_TASK_DEFINITION,
+    UtteranceGenerationPrompt,
+)
 from usersimcrs.user_modeling.persona import Persona
 
 
@@ -16,12 +19,14 @@ def persona() -> Persona:
 
 
 @pytest.fixture
-def prompt(information_need: InformationNeed, persona: Persona) -> Prompt:
+def prompt(
+    information_need: InformationNeed, persona: Persona
+) -> UtteranceGenerationPrompt:
     """Returns a Prompt object."""
-    return Prompt(information_need, "item", persona=persona)
+    return UtteranceGenerationPrompt(information_need, "item", persona=persona)
 
 
-def test_build_new_prompt(prompt: Prompt) -> None:
+def test_build_new_prompt(prompt: UtteranceGenerationPrompt) -> None:
     """Tests the build_new_prompt method."""
     stringified_persona = (
         " Adapt your responses considering your PERSONA.\nPERSONA: "
@@ -35,11 +40,13 @@ def test_build_new_prompt(prompt: Prompt) -> None:
     )
 
     assert prompt.build_new_prompt() == (
-        DEFAULT_TASK_DEFINITION + stringified_persona + stringified_requirements
+        DEFAULT_TASK_DEFINITION
+        + stringified_persona
+        + stringified_requirements
     )
 
 
-def test_update_prompt_context(prompt: Prompt) -> None:
+def test_update_prompt_context(prompt: UtteranceGenerationPrompt) -> None:
     """Tests the update_prompt_context method."""
     user_utterance = Utterance(
         "I am looking for a comedy movie.", DialogueParticipant.USER

--- a/tests/simulator/llm/test_utterance_generation_prompt.py
+++ b/tests/simulator/llm/test_utterance_generation_prompt.py
@@ -33,10 +33,10 @@ def test_build_new_prompt(prompt: UtteranceGenerationPrompt) -> None:
         "curiosity=high, education=MSc\n"
     )
     stringified_requirements = (
-        "REQUIREMENTS: You are looking for a item with the following "
-        "characteristics: GENRE=Comedy, DIRECTOR=Steven Spielberg. Once you "
+        "\nREQUIREMENTS: You are looking for a item with the following "
+        "characteristics: genre=Comedy, director=Steven Spielberg. Once you "
         "find a suitable item, make sure to get the following information: "
-        "PLOT, RATING.\n"
+        "plot, rating.\nHISTORY:\n"
     )
 
     assert prompt.build_new_prompt() == (

--- a/tests/simulator/llm/test_utterance_generation_prompt.py
+++ b/tests/simulator/llm/test_utterance_generation_prompt.py
@@ -40,9 +40,7 @@ def test_build_new_prompt(prompt: UtteranceGenerationPrompt) -> None:
     )
 
     assert prompt.build_new_prompt() == (
-        DEFAULT_TASK_DEFINITION
-        + stringified_persona
-        + stringified_requirements
+        DEFAULT_TASK_DEFINITION + stringified_persona + stringified_requirements
     )
 
 

--- a/usersimcrs/simulator/llm/dual_prompt_user_simulator.py
+++ b/usersimcrs/simulator/llm/dual_prompt_user_simulator.py
@@ -75,7 +75,6 @@ class DualPromptUserSimulator(UserSimulator):
         b_continue = self.llm_interface.get_llm_response(
             self.stop_prompt.prompt_text
         )
-        print(f"Continue conversation: {b_continue}")
         if b_continue.strip().lower() == "false":
             user_utterance = Utterance("\\end", DialogueParticipant.USER)
         else:

--- a/usersimcrs/simulator/llm/dual_prompt_user_simulator.py
+++ b/usersimcrs/simulator/llm/dual_prompt_user_simulator.py
@@ -78,7 +78,7 @@ class DualPromptUserSimulator(UserSimulator):
         if b_continue.strip().lower() == "false":
             user_utterance = Utterance("\\end", DialogueParticipant.USER)
         else:
-            user_utterance = self.llm_interface.generate_response(
+            user_utterance = self.llm_interface.generate_utterance(
                 self.generation_prompt
             )
         self.generation_prompt.update_prompt_context(

--- a/usersimcrs/simulator/llm/dual_prompt_user_simulator.py
+++ b/usersimcrs/simulator/llm/dual_prompt_user_simulator.py
@@ -1,7 +1,8 @@
 """User simulator leveraging a large language model to generate responses.
 
-The responses are generated via a single prompt template with a large language
-model.
+The generation of responses is based on two prompts. The first one establishes
+if the conversation should continue or not. The second one is used to generate
+the user response.
 """
 
 from dialoguekit.core.utterance import Utterance
@@ -9,6 +10,10 @@ from dialoguekit.participant import DialogueParticipant
 from usersimcrs.core.simulation_domain import SimulationDomain
 from usersimcrs.items.item_collection import ItemCollection
 from usersimcrs.simulator.llm.interfaces.llm_interface import LLMInterface
+from usersimcrs.simulator.llm.prompt.stop_prompt import (
+    DEFAULT_STOP_DEFINITION,
+    StopPrompt,
+)
 from usersimcrs.simulator.llm.prompt.utterance_generation_prompt import (
     DEFAULT_TASK_DEFINITION,
     UtteranceGenerationPrompt,
@@ -17,7 +22,7 @@ from usersimcrs.simulator.user_simulator import UserSimulator
 from usersimcrs.user_modeling.persona import Persona
 
 
-class SinglePromptUserSimulator(UserSimulator):
+class DualPromptUserSimulator(UserSimulator):
     def __init__(
         self,
         id: str,
@@ -26,6 +31,7 @@ class SinglePromptUserSimulator(UserSimulator):
         llm_interface: LLMInterface,
         item_type: str,
         task_definition: str = DEFAULT_TASK_DEFINITION,
+        stop_definition: str = DEFAULT_STOP_DEFINITION,
         persona: Persona = None,
     ) -> None:
         """Initializes the user simulator.
@@ -36,12 +42,17 @@ class SinglePromptUserSimulator(UserSimulator):
             item_type: Type of the item to be recommended. Defaults to None.
             task_definition: Definition of the task to be performed.
               Defaults to DEFAULT_TASK_DEFINITION.
+            stop_definition: Definition of the stop task. Defaults to
+              DEFAULT_STOP_DEFINITION.
             persona: Persona of the user. Defaults to None.
         """
         super().__init__(id, domain, item_collection)
         self.llm_interface = llm_interface
-        self.prompt = UtteranceGenerationPrompt(
+        self.generation_prompt = UtteranceGenerationPrompt(
             self.information_need, item_type, task_definition, persona
+        )
+        self.stop_prompt = StopPrompt(
+            self.information_need, item_type, stop_definition, persona
         )
 
     def _generate_response(self, agent_utterance: Utterance) -> Utterance:
@@ -53,11 +64,25 @@ class SinglePromptUserSimulator(UserSimulator):
         Returns:
             User utterance.
         """
-        self.prompt.update_prompt_context(
+        self.generation_prompt.update_prompt_context(
             agent_utterance, DialogueParticipant.AGENT
         )
-        user_utterance = self.llm_interface.generate_response(self.prompt)
-        self.prompt.update_prompt_context(
+        self.stop_prompt.update_prompt_context(
+            agent_utterance, DialogueParticipant.AGENT
+        )
+
+        # Check if the conversation should continue
+        b_continue = self.llm_interface.get_llm_response(
+            self.stop_prompt.prompt_text
+        )
+        print(f"Continue conversation: {b_continue}")
+        if b_continue.strip().lower() == "false":
+            user_utterance = Utterance("\\end", DialogueParticipant.USER)
+        else:
+            user_utterance = self.llm_interface.generate_response(
+                self.generation_prompt
+            )
+        self.generation_prompt.update_prompt_context(
             user_utterance, DialogueParticipant.USER
         )
         return user_utterance

--- a/usersimcrs/simulator/llm/interfaces/llm_interface.py
+++ b/usersimcrs/simulator/llm/interfaces/llm_interface.py
@@ -19,7 +19,9 @@ class LLMInterface(ABC):
         self.default_response = default_response
 
     @abstractmethod
-    def generate_response(self, prompt: UtteranceGenerationPrompt) -> Utterance:
+    def generate_utterance(
+        self, prompt: UtteranceGenerationPrompt
+    ) -> Utterance:
         """Generates an utterance given a prompt.
 
         Args:

--- a/usersimcrs/simulator/llm/interfaces/llm_interface.py
+++ b/usersimcrs/simulator/llm/interfaces/llm_interface.py
@@ -34,7 +34,7 @@ class LLMInterface(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_llm_response(self, prompt: str) -> str:
+    def get_llm_response(self, prompt: str, **kwargs) -> str:
         """Generates a response given a prompt.
 
         Args:

--- a/usersimcrs/simulator/llm/interfaces/llm_interface.py
+++ b/usersimcrs/simulator/llm/interfaces/llm_interface.py
@@ -3,8 +3,9 @@
 from abc import ABC, abstractmethod
 
 from dialoguekit.core import Utterance
-
-from usersimcrs.simulator.llm.prompt import Prompt
+from usersimcrs.simulator.llm.prompt.utterance_generation_prompt import (
+    UtteranceGenerationPrompt,
+)
 
 
 class LLMInterface(ABC):
@@ -18,7 +19,7 @@ class LLMInterface(ABC):
         self.default_response = default_response
 
     @abstractmethod
-    def generate_response(self, prompt: Prompt) -> Utterance:
+    def generate_response(self, prompt: UtteranceGenerationPrompt) -> Utterance:
         """Generates an utterance given a prompt.
 
         Args:
@@ -29,5 +30,20 @@ class LLMInterface(ABC):
 
         Returns:
             Utterance.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_llm_response(self, prompt: str) -> str:
+        """Generates a response given a prompt.
+
+        Args:
+            prompt: Prompt for generating the response.
+
+        Raises:
+            NotImplementedError: If the method is not implemented in subclass.
+
+        Returns:
+            Response.
         """
         raise NotImplementedError()

--- a/usersimcrs/simulator/llm/interfaces/ollama_interface.py
+++ b/usersimcrs/simulator/llm/interfaces/ollama_interface.py
@@ -53,7 +53,9 @@ class OllamaLLMInterface(LLMInterface):
             **self._llm_configuration.get("options", {})
         )
 
-    def generate_response(self, prompt: UtteranceGenerationPrompt) -> Utterance:
+    def generate_utterance(
+        self, prompt: UtteranceGenerationPrompt
+    ) -> Utterance:
         """Generates a user utterance given a prompt.
 
         Args:

--- a/usersimcrs/simulator/llm/interfaces/ollama_interface.py
+++ b/usersimcrs/simulator/llm/interfaces/ollama_interface.py
@@ -8,7 +8,9 @@ from ollama import Client, Options
 from dialoguekit.core import Utterance
 from dialoguekit.participant import DialogueParticipant
 from usersimcrs.simulator.llm.interfaces.llm_interface import LLMInterface
-from usersimcrs.simulator.llm.prompt import Prompt
+from usersimcrs.simulator.llm.prompt.utterance_generation_prompt import (
+    UtteranceGenerationPrompt,
+)
 
 
 class OllamaLLMInterface(LLMInterface):
@@ -51,7 +53,7 @@ class OllamaLLMInterface(LLMInterface):
             **self._llm_configuration.get("options", {})
         )
 
-    def generate_response(self, prompt: Prompt) -> Utterance:
+    def generate_response(self, prompt: UtteranceGenerationPrompt) -> Utterance:
         """Generates a user utterance given a prompt.
 
         Args:
@@ -60,11 +62,25 @@ class OllamaLLMInterface(LLMInterface):
         Returns:
             Utterance.
         """
+        response = self.get_llm_response(prompt.prompt_text)
+        if response == "":
+            response = self.default_response
+        response = response.replace("USER: ", "")
+        return Utterance(response, participant=DialogueParticipant.USER)
+
+    def get_llm_response(self, prompt: str) -> str:
+        """Generates a response given a prompt.
+
+        Args:
+            prompt: Prompt for generating the response.
+
+        Returns:
+            Response.
+        """
         ollama_response = self.client.generate(
             self.model,
-            prompt.prompt_text,
+            prompt,
             options=self._llm_options,
             stream=self._stream,
         )
-        response = ollama_response.get("response", self.default_response)
-        return Utterance(response, participant=DialogueParticipant.USER)
+        return ollama_response.get("response", "")

--- a/usersimcrs/simulator/llm/interfaces/openai_interface.py
+++ b/usersimcrs/simulator/llm/interfaces/openai_interface.py
@@ -62,7 +62,9 @@ class OpenAILLMInterface(LLMInterface):
         self.client = OpenAI(api_key=self._llm_configuration.get("api_key"))
         self.use_chat_api = use_chat_api
 
-    def generate_response(self, prompt: UtteranceGenerationPrompt) -> Utterance:
+    def generate_utterance(
+        self, prompt: UtteranceGenerationPrompt
+    ) -> Utterance:
         """Generates a user utterance given a prompt.
 
         Args:

--- a/usersimcrs/simulator/llm/interfaces/openai_interface.py
+++ b/usersimcrs/simulator/llm/interfaces/openai_interface.py
@@ -71,7 +71,9 @@ class OpenAILLMInterface(LLMInterface):
         Returns:
             Utterance.
         """
-        response = self.get_llm_response(prompt)
+        response = self.get_llm_response(
+            prompt.prompt_text, initial_prompt=prompt.build_new_prompt()
+        )
         response = response.replace("USER: ", "")
         return Utterance(response, DialogueParticipant.USER)
 
@@ -94,19 +96,20 @@ class OpenAILLMInterface(LLMInterface):
                 messages.append({"role": role.lower(), "content": text})
         return messages
 
-    def get_llm_response(self, prompt: str) -> str:
+    def get_llm_response(self, prompt: str, initial_prompt: str = None) -> str:
         """Generates a response given a prompt.
 
         Args:
             prompt: Prompt for generating the response.
+            initial_prompt: Initial prompt to be used in the chat API.
 
         Returns:
             Response.
         """
         if self.use_chat_api:
             messages = [
-                {"role": "system", "content": prompt.build_new_prompt()},
-                *self._parse_prompt_context(prompt.prompt_text),
+                {"role": "system", "content": initial_prompt},
+                *self._parse_prompt_context(prompt),
             ]
             response = (
                 self.client.chat.completions.create(

--- a/usersimcrs/simulator/llm/prompt/prompt.py
+++ b/usersimcrs/simulator/llm/prompt/prompt.py
@@ -1,0 +1,64 @@
+"""Interface for prompt."""
+
+from abc import ABC, abstractmethod
+
+from dialoguekit.core.utterance import Utterance
+from dialoguekit.participant.participant import DialogueParticipant
+from usersimcrs.core.information_need import InformationNeed
+from usersimcrs.user_modeling.persona import Persona
+
+
+class Prompt(ABC):
+    def __init__(
+        self,
+        information_need: InformationNeed,
+        item_type: str,
+        prompt_definition: str,
+        persona: Persona = None,
+    ) -> None:
+        """Initializes the prompt.
+
+        Args:
+            information_need: The information need of the user.
+            item_type: The type of the item to be recommended.
+            prompt_definition: The definition of the task to be performed.
+            persona: The persona of the user. Defaults to None.
+        """
+        self.information_need = information_need
+        self.item_type = item_type
+        self.prompt_definition = prompt_definition
+        self.persona = persona
+        self._initial_prompt = self.build_new_prompt()
+        self._prompt_context = ""
+
+    @property
+    def prompt_text(self) -> str:
+        """Prompt for the user simulator."""
+        return self._initial_prompt + "\n" + self._prompt_context
+
+    @abstractmethod
+    def build_new_prompt(self, **kwargs) -> str:
+        """Builds the initial prompt without any context.
+
+        Raises:
+            NotImplementedError: If the method is not implemented in subclasses.
+
+        Returns:
+            Initial prompt.
+        """
+        raise NotImplementedError
+
+    def update_prompt_context(
+        self, utterance: Utterance, participant: DialogueParticipant
+    ) -> None:
+        """Updates the context provided in the prompt.
+
+        Args:
+            utterance: Utterance to be added to the prompt.
+            participant: Participant of the conversation.
+        """
+        role = (
+            "ASSISTANT" if participant == DialogueParticipant.AGENT else "USER"
+        )
+
+        self._prompt_context += f"{role}: {utterance.text}\n"

--- a/usersimcrs/simulator/llm/prompt/stop_prompt.py
+++ b/usersimcrs/simulator/llm/prompt/stop_prompt.py
@@ -1,0 +1,85 @@
+"""Define the prompt for stopping the conversation."""
+
+from usersimcrs.core.information_need import InformationNeed
+from usersimcrs.simulator.llm.prompt.prompt import Prompt
+from usersimcrs.user_modeling.persona import Persona
+
+DEFAULT_STOP_DEFINITION = (
+    "You are a USER discussing with an ASSISTANT to get a recommendation "
+    "meeting your REQUIREMENTS. Given the conversation history, you need to "
+    "decide whether to continue the conversation or not. Detect if the "
+    "conversation is not progressing towards your goal or if the ASSISTANT is "
+    "not helpful. In such cases, you should terminate the conversation by "
+    "returning TRUE. Otherwise, return FALSE."
+)
+
+
+class StopPrompt(Prompt):
+    def __init__(
+        self,
+        information_need: InformationNeed,
+        item_type: str,
+        prompt_definition: str = DEFAULT_STOP_DEFINITION,
+        persona: Persona = None,
+    ) -> None:
+        """Initializes the prompt.
+
+        Args:
+            information_need: The information need of the user.
+            item_type: The type of the item to be recommended.
+            prompt_definition: The definition of the task to be performed.
+              Defaults to DEFAULT_STOP_DEFINITION.
+            persona: The persona of the user. Defaults to None.
+        """
+        super().__init__(
+            information_need, item_type, prompt_definition, persona
+        )
+
+    @property
+    def prompt_text(self) -> str:
+        """Prompt for the user simulator."""
+        return (
+            self._initial_prompt
+            + "\n"
+            + self._prompt_context
+            + "\n"
+            + "CONTINUE: "
+        )
+
+    def build_new_prompt(self) -> str:
+        """Builds the initial prompt without any context.
+
+        Returns:
+            Initial prompt with task definition, requirements, and persona.
+        """
+        initial_prompt = self.prompt_definition
+
+        if self.persona:
+            initial_prompt += (
+                " Take into account your PERSONA when deciding to stop the "
+                "conversation.\n"
+            )
+            stringified_characteristics = ", ".join(
+                [
+                    f"{key}={value}"
+                    for key, value in self.persona.characteristics.items()
+                ]
+            )
+            initial_prompt += f"PERSONA: {stringified_characteristics}\n"
+
+        stringified_constraints = ", ".join(
+            [
+                f"{key.lower()}={value}"
+                for key, value in self.information_need.constraints.items()
+            ]
+        )
+        requestable_slot = ", ".join(
+            [k.lower() for k in self.information_need.requested_slots.keys()]
+        )
+        initial_prompt += (
+            f"\nREQUIREMENTS: You are looking for a {self.item_type} with the "
+            f"following characteristics: {stringified_constraints} and want to "
+            f"know the following information about it: {requestable_slot}.\n"
+            "HISTORY:\n"
+        )
+        return initial_prompt

--- a/usersimcrs/simulator/llm/prompt/utterance_generation_prompt.py
+++ b/usersimcrs/simulator/llm/prompt/utterance_generation_prompt.py
@@ -9,47 +9,45 @@ Reference: Terragni, S., et al. (2023). "In-Context Learning User Simulators
 for Task-Oriented Dialog Systems", arXiv 2306.00774.
 """
 
-from dialoguekit.core import Utterance
-from dialoguekit.participant import DialogueParticipant
-
+from dialoguekit.core.utterance import Utterance
+from dialoguekit.participant.participant import DialogueParticipant
 from usersimcrs.core.information_need import InformationNeed
+from usersimcrs.simulator.llm.prompt.prompt import Prompt
 from usersimcrs.user_modeling.persona import Persona
 
 DEFAULT_TASK_DEFINITION = (
-    "Complete the conversation as a CUSTOMER discussing with an ASSISTANT. The "
-    "conversation is about getting a recommendation according to the "
-    "REQUIREMENTS. You must fulfill all REQUIREMENTS."
+    "You are a USER discussing with an ASSISTANT. Given the conversation "
+    "history, you need to generate the next USER message in the most natural "
+    "way possible. The conversation is about getting a recommendation "
+    "according to the REQUIREMENTS. You must fulfill all REQUIREMENTS as the "
+    "conversation progresses (you don't need to fulfill them all at once). "
+    "After getting all the necessary information, you can terminate the "
+    "conversation by sending '\\end'. You may also terminate the conversation "
+    "is not going anywhere or the ASSISTANT is not helpful by sending "
+    "'\\giveup'. "
 )
 
 
-class Prompt:
+class UtteranceGenerationPrompt(Prompt):
     def __init__(
         self,
-        requirements: InformationNeed,
+        information_need: InformationNeed,
         item_type: str,
-        task_definition: str = DEFAULT_TASK_DEFINITION,
+        prompt_definition: str = DEFAULT_TASK_DEFINITION,
         persona: Persona = None,
     ) -> None:
         """Initializes the prompt.
 
         Args:
-            requirements: The information need of the user.
+            information_need: The information need of the user.
             item_type: The type of the item to be recommended.
-            task_definition: The definition of the task to be performed.
+            prompt_definition: The definition of the task to be performed.
               Defaults to DEFAULT_TASK_DEFINITION.
             persona: The persona of the user. Defaults to None.
         """
-        self.requirements = requirements
-        self.item_type = item_type
-        self.task_definition = task_definition
-        self.persona = persona
-        self._initial_prompt = self.build_new_prompt()
-        self._prompt_context = ""
-
-    @property
-    def prompt_text(self) -> str:
-        """Prompt for the user simulator."""
-        return self._initial_prompt + "\n" + self._prompt_context
+        super().__init__(
+            information_need, item_type, prompt_definition, persona
+        )
 
     def build_new_prompt(self) -> str:
         """Builds the initial prompt without any context.
@@ -57,7 +55,7 @@ class Prompt:
         Returns:
             Initial prompt with task definition, requirements, and persona.
         """
-        initial_prompt = self.task_definition
+        initial_prompt = self.prompt_definition
 
         if self.persona:
             initial_prompt += (
@@ -77,16 +75,18 @@ class Prompt:
 
         stringified_constraints = ", ".join(
             [
-                f"{key}={value}"
-                for key, value in self.requirements.constraints.items()
+                f"{key.lower()}={value}"
+                for key, value in self.information_need.constraints.items()
             ]
         )
-        requestable_slot = ", ".join(self.requirements.requested_slots.keys())
+        requestable_slot = ", ".join(
+            [k.lower() for k in self.information_need.requested_slots.keys()]
+        )
         initial_prompt += (
-            f"REQUIREMENTS: You are looking for a {self.item_type} with the "
+            f"\nREQUIREMENTS: You are looking for a {self.item_type} with the "
             f"following characteristics: {stringified_constraints}. Once you "
             f"find a suitable {self.item_type}, make sure to get the following "
-            f"information: {requestable_slot}.\n"
+            f"information: {requestable_slot}.\nHISTORY:\n"
         )
         return initial_prompt
 
@@ -99,10 +99,6 @@ class Prompt:
             utterance: Utterance to be added to the prompt.
             participant: Participant of the conversation.
         """
-        role = (
-            "ASSISTANT" if participant == DialogueParticipant.AGENT else "USER"
-        )
-
-        self._prompt_context += f"{role}: {utterance.text}\n"
+        super().update_prompt_context(utterance, participant)
         if participant == DialogueParticipant.AGENT:
             self._prompt_context += "USER: "

--- a/usersimcrs/simulator/llm/prompt/utterance_generation_prompt.py
+++ b/usersimcrs/simulator/llm/prompt/utterance_generation_prompt.py
@@ -23,7 +23,7 @@ DEFAULT_TASK_DEFINITION = (
     "conversation progresses (you don't need to fulfill them all at once). "
     "After getting all the necessary information, you can terminate the "
     "conversation by sending '\\end'. You may also terminate the conversation "
-    "is not going anywhere or the ASSISTANT is not helpful by sending "
+    "if it is not going anywhere or the ASSISTANT is not helpful by sending "
     "'\\giveup'. "
 )
 

--- a/usersimcrs/simulator/llm/simple_prompt_user_simulator.py
+++ b/usersimcrs/simulator/llm/simple_prompt_user_simulator.py
@@ -56,7 +56,7 @@ class SinglePromptUserSimulator(UserSimulator):
         self.prompt.update_prompt_context(
             agent_utterance, DialogueParticipant.AGENT
         )
-        user_utterance = self.llm_interface.generate_response(self.prompt)
+        user_utterance = self.llm_interface.generate_utterance(self.prompt)
         self.prompt.update_prompt_context(
             user_utterance, DialogueParticipant.USER
         )


### PR DESCRIPTION
## What's changed?

* Update LLM interfaces to get model response
* Create interface for prompts with two subclasses for utterance generation prompt and stop prompt
* Add new LLM US which uses two prompts: (1) decide to continue or stop the conversation and (2) generate the next user utterance
* Add tests for stop prompt